### PR TITLE
Add configuration for flattening package directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ applications:
   buildpacks:
   - https://github.com/cloudfoundry/apt-buildpack.git
   - staticfile_buildpack
+  env:
+    FLATTEN: true
 ```
+
+Set `FLATTEN=false` if you'd like to keep the original directory structure of the package installed by the apt-buildpack.  This can be helpful if you need to futher process the results or trim some of the artifacts before pulling it into your repository or application.
 
 ## Push to PCF
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,3 +9,5 @@ applications:
   buildpacks:
   - https://github.com/cloudfoundry/apt-buildpack.git
   - staticfile_buildpack
+  env:
+    FLATTEN: true

--- a/public/package.sh
+++ b/public/package.sh
@@ -6,8 +6,14 @@ PACKAGE=`tail -n1 $HOME/public/apt.yml | awk '{print $2}'`
 #make the directory to put the binaries
 mkdir $HOME/public/$PACKAGE
 
-#copy the binaries and flatten into the directory above
-cp `find -L $HOME/../deps/0/ -type f | awk -F/ '{a[$NF]=$0}END{for(i in a)print a[i]}'` $HOME/public/$PACKAGE
+#copy the binaries
+if [ ! "$FLATTEN" = false ]; then
+  # default to flatten binaries into the packaging directory
+  cp `find -L $HOME/../deps/0/ -type f | awk -F/ '{a[$NF]=$0}END{for(i in a)print a[i]}'` $HOME/public/$PACKAGE
+else
+  # package the binaries directory unmodified
+  cp -R $HOME/../deps/0/ $HOME/public/$PACKAGE
+fi
 
 #cd into directory so the structure of the zip is correct
 cd $HOME/public/


### PR DESCRIPTION
I've added an environment variable `FLATTEN` that can be set to false to skip the flattening of the package's directory structure.  This is useful if you only need parts of the final package, or need the context of where certain files might be used in your application.

In an example use case, we used this project to package `apache2-mod-perl` for use in CF containers, but we needed to be able to pull out the native modules and put them in one place, the Perl modules and place them in another place, etc.  Keeping the directory structure allowed us to sift through the results and copy the right artifacts into the correct locations within our application.